### PR TITLE
Fix broken "jobs" link in footer

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -92,7 +92,7 @@ const Footer = props => (
                         </a>
                     </dd>
                     <dd>
-                        <a href="https://www.scratchfoundation.org/opportunities">
+                        <a href="https://www.scratchfoundation.org/careers">
                             <FormattedMessage id="general.jobs" />
                         </a>
                     </dd>


### PR DESCRIPTION
### Resolves:

Resolves #7396

### Changes:

Changes the jobs link in the footer to link to [https://www.scratchfoundation.org/careers](url)
